### PR TITLE
feat(pg_handler): add tuple handling

### DIFF
--- a/apps/pg_subscriptor/lib/column.ex
+++ b/apps/pg_subscriptor/lib/column.ex
@@ -1,0 +1,66 @@
+defmodule PgSubscriber.Column do
+
+  alias __MODULE__
+
+  @type kind :: ?n | ?u | ?t | ?b
+  @type col_val :: nil | binary | String.t()
+  @type t :: %__MODULE__{
+    kind: kind,
+    value: col_val,
+  }
+
+  defstruct [:kind, :value]
+
+  @spec get_cols(non_neg_integer(), binary()) ::
+    {:ok, [Column.t()], binary()}
+    | {:error, term()}
+  @doc """
+  Parses all Columns from a single TupleData in a binary message and returns the parsed list of Column structs and the remaining binary.
+  In case of invalid format, an error with reason is returned.
+  """
+  def get_cols(0, data) do
+    {:ok, [], data}
+  end
+
+  def get_cols(num_of_cols, data) do
+    with <<kind::8, rest_after_kind::binary>> <- data,
+    {:ok, value, rest_after_parse_col} <- parse_column_from_binary(kind, rest_after_kind),
+    {:ok, cols, rest_final} <- get_cols(num_of_cols - 1, rest_after_parse_col) do
+      {:ok, [%Column{kind: kind, value: value} | cols], rest_final}
+    else
+      {:error, reason} -> {:error, reason}
+      _ -> {:error, {:invalid_kind_length, data}}
+    end
+  end
+
+  defp parse_column_from_binary(kind, data) do
+    case kind do
+      ?b ->
+        parse_length_prefixed_value_from_binary(data, & &1)
+      ?t ->
+        parse_length_prefixed_value_from_binary(data, &to_string/1)
+
+      col when col in [?n, ?u] ->
+        {:ok, nil, data}
+
+      _ ->
+        {:error, {:unsupported_column_type, kind}}
+    end
+  end
+
+  defp parse_length_prefixed_value_from_binary(data, processor) do
+    case data do
+      <<col_length::32, rest::binary>> ->
+        case rest do
+          <<value::binary-size(col_length), rest_after::binary>> ->
+            {:ok, processor.(value), rest_after}
+
+          _ ->
+            {:error, {:incomplete_column_value, col_length, rest}}
+        end
+
+      _ ->
+        {:error, {:invalid_column_length_prefix, data}}
+    end
+  end
+end

--- a/apps/pg_subscriptor/lib/tuple_data.ex
+++ b/apps/pg_subscriptor/lib/tuple_data.ex
@@ -1,0 +1,29 @@
+defmodule PgSubscriber.TupleData do
+
+  alias __MODULE__
+  alias PgSubscriber.Column
+
+  @type t :: %__MODULE__{
+    num_of_cols: integer,
+    columns: [Column.t()],
+  }
+
+  defstruct [:num_of_cols, :columns]
+
+  @spec get_tuple_data(binary()) ::
+    {:ok, TupleData.t(), binary()}
+    | {:error, term()}
+  @doc """
+  Parses a TupleData binary message and returns the parsed TupleData struct and the remaining binary.
+  In case of invalid format, an error with reason is returned.
+  """
+  def get_tuple_data(data) do
+    with <<num_of_cols::16, rest::binary>> <- data,
+    {:ok, columns, rest} <- Column.get_cols(num_of_cols, rest) do
+      {:ok, %TupleData{num_of_cols: num_of_cols, columns: columns}, rest}
+    else
+      {:error, reason} -> {:error, reason}
+      _ -> {:error, {:invalid_data_length, data}}
+    end
+  end
+end

--- a/apps/pg_subscriptor/test/tuple_data_test.exs
+++ b/apps/pg_subscriptor/test/tuple_data_test.exs
@@ -1,0 +1,62 @@
+defmodule TupleDataTest do
+  use ExUnit.Case
+  alias PgSubscriber.TupleData
+  alias PgSubscriber.Column
+
+  doctest TupleData
+
+  test "get_tuple_data" do
+    message = <<6::16, "n", "b", 5::32, "Filip", "u", "b", 1::32, "D", "t", 5::32, "Juraj", "n", 55::32, 1::16, "n">>
+    assert {:ok, tuple_data, rest} = TupleData.get_tuple_data(message)
+    assert tuple_data == %TupleData{num_of_cols: 6, columns: [
+      %Column{kind: ?n, value: nil},
+      %Column{kind: ?b, value: "Filip"},
+      %Column{kind: ?u, value: nil},
+      %Column{kind: ?b, value: "D"},
+      %Column{kind: ?t, value: "Juraj"},
+      %Column{kind: ?n, value: nil},
+    ]}
+    assert rest == <<55::32, 1::16, "n">>
+  end
+
+  test "get_tuple_data_empty" do
+    message = <<0::16, "Juraj", "n", 55::32, 1::16, "n">>
+    assert {:ok, tuple_data, rest} = TupleData.get_tuple_data(message)
+    assert tuple_data == %TupleData{num_of_cols: 0, columns: []}
+    assert rest == <<"Juraj", "n", 55::32, 1::16, "n">>
+  end
+
+  test "get_tuple_data_invalid_col_type" do
+    message = <<1::16, "x">>
+    assert {:error, result} = TupleData.get_tuple_data(message)
+    assert result == {:unsupported_column_type, ?x}
+  end
+
+  test "get_tuple_data_invalid_col_len" do
+    message = <<1::16, "t", 5::16>>
+    assert {:error, result} = TupleData.get_tuple_data(message)
+    assert result == {:invalid_column_length_prefix, <<0, 5>>}
+  end
+
+  test "get_tuple_data_invalid_col_val" do
+    message = <<1::16, "t", 5::32, "Fili">>
+    assert {:error, result} = TupleData.get_tuple_data(message)
+    assert result == {:incomplete_column_value, 5, <<"Fili">>}
+
+    message = <<1::16, "t", 5::16, "Filip">>
+    assert {:error, result} = TupleData.get_tuple_data(message)
+    assert result == {:incomplete_column_value, 345705, <<"lip">>}
+  end
+
+  test "get_tuple_data_invalid_length" do
+    message = <<1::8>>
+    assert {:error, result} = TupleData.get_tuple_data(message)
+    assert result == {:invalid_data_length, message}
+  end
+
+  test "get_tuple_data_invalid_length_kind" do
+    message = <<1::16>>
+    assert {:error, result} = TupleData.get_tuple_data(message)
+    assert result == {:invalid_kind_length, <<>>}
+  end
+end


### PR DESCRIPTION
Not sure if the actual data looks like this, but from the documentation, I think so.

We might want to use some struct instead of `{col_type, value}` or something.

And I think that we should start to modularise more. So that `get_tuple_data` is in a separate file.
Besides classic reasons, it has to be public if we want to test it.